### PR TITLE
menu ui tweaks

### DIFF
--- a/Scenes/UI/Lobby/BattlePlayerSlotPanel.tscn
+++ b/Scenes/UI/Lobby/BattlePlayerSlotPanel.tscn
@@ -63,11 +63,6 @@ layout_mode = 2
 size_flags_horizontal = 0
 text = "Take"
 
-[node name="ButtonAI" type="Button" parent="VBoxContainer/HBoxContainer"]
-custom_minimum_size = Vector2(200, 0)
-layout_mode = 2
-text = "Human"
-
 [node name="ButtonColor" type="Button" parent="VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
@@ -94,7 +89,6 @@ custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/ButtonTakeLeave" to="." method="_on_button_take_leave_pressed"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/ButtonAI" to="." method="_on_button_ai_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/ButtonColor" to="." method="_on_button_color_pressed"]
 [connection signal="pressed" from="VBoxContainer/OptionButtonUnit1" to="." method="_on_button_faction_pressed"]
 [connection signal="pressed" from="VBoxContainer/OptionButtonUnit2" to="." method="_on_button_faction_pressed"]

--- a/Scenes/UI/MainMenu.tscn
+++ b/Scenes/UI/MainMenu.tscn
@@ -26,6 +26,27 @@ size_flags_horizontal = 3
 [node name="TopMenu" type="HBoxContainer" parent="MainContainer"]
 layout_mode = 2
 size_flags_vertical = 0
+theme_override_constants/separation = 20
+
+[node name="HostButton" type="Button" parent="MainContainer/TopMenu"]
+modulate = Color(1, 1, 0, 1)
+layout_mode = 2
+text = "Host
+"
+
+[node name="JoinButton" type="Button" parent="MainContainer/TopMenu"]
+layout_mode = 2
+text = "Join
+"
+
+[node name="SettingsButton" type="Button" parent="MainContainer/TopMenu"]
+layout_mode = 2
+text = "Settings"
+
+[node name="VSeparator" type="VSeparator" parent="MainContainer/TopMenu"]
+layout_mode = 2
+theme_override_constants/separation = 92
+theme_override_styles/separator = SubResource("StyleBoxLine_3lov4")
 
 [node name="EditorsMenuBar" type="MenuBar" parent="MainContainer/TopMenu"]
 layout_mode = 2
@@ -50,27 +71,6 @@ item_count = 1
 item_0/text = "Run Replay"
 item_0/id = 0
 
-[node name="MultiplayerMenuBar" type="MenuBar" parent="MainContainer/TopMenu"]
-layout_mode = 2
-prefer_global_menu = false
-
-[node name="Multiplayer" type="PopupMenu" parent="MainContainer/TopMenu/MultiplayerMenuBar"]
-size = Vector2i(247, 126)
-item_count = 2
-item_0/text = "Host server"
-item_0/id = 0
-item_1/text = "Join"
-item_1/id = 1
-
-[node name="VSeparator" type="VSeparator" parent="MainContainer/TopMenu"]
-layout_mode = 2
-theme_override_constants/separation = 92
-theme_override_styles/separator = SubResource("StyleBoxLine_3lov4")
-
-[node name="SettingsButton" type="Button" parent="MainContainer/TopMenu"]
-layout_mode = 2
-text = "Settings"
-
 [node name="HostLobby" parent="MainContainer" instance=ExtResource("2_eyp7f")]
 layout_mode = 2
 size_flags_vertical = 3
@@ -93,8 +93,9 @@ access = 1
 root_subfolder = "replays/"
 
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
+[connection signal="pressed" from="MainContainer/TopMenu/HostButton" to="." method="_on_host_button_pressed"]
+[connection signal="pressed" from="MainContainer/TopMenu/JoinButton" to="." method="_on_join_button_pressed"]
+[connection signal="pressed" from="MainContainer/TopMenu/SettingsButton" to="." method="_on_settings_button_pressed"]
 [connection signal="id_pressed" from="MainContainer/TopMenu/EditorsMenuBar/Editors" to="." method="_on_editors_menu_id_pressed"]
 [connection signal="id_pressed" from="MainContainer/TopMenu/ReplaysMenuBar/Replays" to="." method="_on_replays_id_pressed"]
-[connection signal="id_pressed" from="MainContainer/TopMenu/MultiplayerMenuBar/Multiplayer" to="." method="_on_multiplayer_id_pressed"]
-[connection signal="pressed" from="MainContainer/TopMenu/SettingsButton" to="." method="_on_settings_button_pressed"]
 [connection signal="file_selected" from="FileDialogReplay" to="." method="_on_file_dialog_replay_file_selected"]

--- a/Scenes/UI/MainMenu.tscn
+++ b/Scenes/UI/MainMenu.tscn
@@ -31,12 +31,12 @@ theme_override_constants/separation = 20
 [node name="HostButton" type="Button" parent="MainContainer/TopMenu"]
 modulate = Color(1, 1, 0, 1)
 layout_mode = 2
-text = "Host
+text = " >> Host << 
 "
 
 [node name="JoinButton" type="Button" parent="MainContainer/TopMenu"]
 layout_mode = 2
-text = "Join
+text = " -- Join -- 
 "
 
 [node name="SettingsButton" type="Button" parent="MainContainer/TopMenu"]
@@ -48,28 +48,19 @@ layout_mode = 2
 theme_override_constants/separation = 92
 theme_override_styles/separator = SubResource("StyleBoxLine_3lov4")
 
-[node name="EditorsMenuBar" type="MenuBar" parent="MainContainer/TopMenu"]
+[node name="ReplaysButton" type="Button" parent="MainContainer/TopMenu"]
 layout_mode = 2
-theme_override_constants/h_separation = 0
-prefer_global_menu = false
+text = "Replays"
 
-[node name="Editors" type="PopupMenu" parent="MainContainer/TopMenu/EditorsMenuBar"]
-size = Vector2i(238, 126)
-item_count = 2
-item_0/text = "Map Editor"
-item_0/id = 0
-item_1/text = "Unit Editor"
-item_1/id = 1
-
-[node name="ReplaysMenuBar" type="MenuBar" parent="MainContainer/TopMenu"]
+[node name="UnitEditorButton" type="Button" parent="MainContainer/TopMenu"]
 layout_mode = 2
-prefer_global_menu = false
+text = "Unit Editor
+"
 
-[node name="Replays" type="PopupMenu" parent="MainContainer/TopMenu/ReplaysMenuBar"]
-size = Vector2i(243, 100)
-item_count = 1
-item_0/text = "Run Replay"
-item_0/id = 0
+[node name="MapEditorButton" type="Button" parent="MainContainer/TopMenu"]
+layout_mode = 2
+text = "Map Editor
+"
 
 [node name="HostLobby" parent="MainContainer" instance=ExtResource("2_eyp7f")]
 layout_mode = 2
@@ -96,6 +87,7 @@ root_subfolder = "replays/"
 [connection signal="pressed" from="MainContainer/TopMenu/HostButton" to="." method="_on_host_button_pressed"]
 [connection signal="pressed" from="MainContainer/TopMenu/JoinButton" to="." method="_on_join_button_pressed"]
 [connection signal="pressed" from="MainContainer/TopMenu/SettingsButton" to="." method="_on_settings_button_pressed"]
-[connection signal="id_pressed" from="MainContainer/TopMenu/EditorsMenuBar/Editors" to="." method="_on_editors_menu_id_pressed"]
-[connection signal="id_pressed" from="MainContainer/TopMenu/ReplaysMenuBar/Replays" to="." method="_on_replays_id_pressed"]
+[connection signal="pressed" from="MainContainer/TopMenu/ReplaysButton" to="." method="_on_replays_button_pressed"]
+[connection signal="pressed" from="MainContainer/TopMenu/UnitEditorButton" to="." method="_on_unit_editor_button_pressed"]
+[connection signal="pressed" from="MainContainer/TopMenu/MapEditorButton" to="." method="_on_map_editor_button_pressed"]
 [connection signal="file_selected" from="FileDialogReplay" to="." method="_on_file_dialog_replay_file_selected"]

--- a/Scripts/UI/Lobby/battle_player_slot_panel.gd
+++ b/Scripts/UI/Lobby/battle_player_slot_panel.gd
@@ -16,7 +16,6 @@ var button_take_leave_state : TakeLeaveButtonState = TakeLeaveButtonState.FREE
 
 @onready var button_take_leave = $VBoxContainer/HBoxContainer/ButtonTakeLeave
 @onready var label_name = $VBoxContainer/HBoxContainer/PlayerInfoPanel/Label
-@onready var button_ai = $VBoxContainer/HBoxContainer/ButtonAI
 @onready var buttons_units : Array[OptionButton] = [
 	$VBoxContainer/OptionButtonUnit1,
 	$VBoxContainer/OptionButtonUnit2,
@@ -41,12 +40,6 @@ func cycle_color(backwards : bool = false):
 	if not setup_ui:
 		return
 	setup_ui.cycle_color_slot(self, backwards)
-
-
-func cycle_ai(backwards : bool = false):
-	if not setup_ui:
-		return
-	setup_ui.cycle_ai_slot(self, backwards)
 
 
 func set_visible_color(c : Color):
@@ -93,7 +86,9 @@ func _ready():
 
 func unit_in_army_changed(selected_index, unit_index):
 	var unit_path = buttons_units[unit_index].get_item_text(selected_index)
-	var unit_data = load(CFG.UNITS_PATH+"/"+unit_path)
+	var unit_data : DataUnit = null
+	if unit_path != EMPTY_UNIT_TEXT:
+		unit_data = load(CFG.UNITS_PATH+"/"+unit_path)
 	var slot_index = setup_ui.slot_to_index(self)
 	IM.game_setup_info.set_unit(slot_index, unit_index, unit_data)
 	if NET.server:
@@ -143,7 +138,3 @@ func _on_button_take_leave_pressed():
 
 func _on_button_color_pressed():
 	cycle_color()
-
-
-func _on_button_ai_pressed():
-	cycle_ai()

--- a/Scripts/UI/Lobby/battle_setup.gd
+++ b/Scripts/UI/Lobby/battle_setup.gd
@@ -59,7 +59,6 @@ func refresh_slot(index : int):
 	if logic_slot:
 		ui_slot.set_army(logic_slot.units_list)
 		if logic_slot.occupier is String:
-			ui_slot.button_ai.text = "HUMAN"
 			if logic_slot.occupier == "":
 				username = NET.get_current_login()
 				take_leave_button_state = \
@@ -69,7 +68,6 @@ func refresh_slot(index : int):
 				take_leave_button_state = \
 					BattlePlayerSlotPanel.TakeLeaveButtonState.TAKEN_BY_OTHER
 		else:
-			ui_slot.button_ai.text = "AI"
 			username = "Computer\nlevel %d" % logic_slot.occupier
 			take_leave_button_state = \
 				BattlePlayerSlotPanel.TakeLeaveButtonState.FREE
@@ -123,22 +121,6 @@ func cycle_faction_slot(slot : BattlePlayerSlotPanel, backwards : bool) -> bool:
 	if changed:
 		refresh_slot(index)
 	return changed
-
-func cycle_ai_slot(slot : BattlePlayerSlotPanel, _backwards : bool):
-	if NET.client:
-		return
-	var index : int = slot_to_index(slot)
-	if not IM.game_setup_info.has_slot(index):
-		push_error("cycle_ai_slot no slot on index", index)
-		return
-	var logic_slot = IM.game_setup_info.slots[index]
-	if logic_slot.is_bot():
-		logic_slot.occupier = ""
-	else:
-		logic_slot.occupier = 1
-	refresh_slot(index)
-	if NET.server:
-		NET.server.broadcast_full_game_setup(IM.game_setup_info)
 
 
 func rebuild():

--- a/Scripts/UI/main_menu.gd
+++ b/Scripts/UI/main_menu.gd
@@ -13,22 +13,7 @@ func _ready():
 
 
 func refresh_replays_disabled():
-	$MainContainer/TopMenu/ReplaysMenuBar/Replays.set_item_disabled(0, not BattleReplay.has_replays())
-
-
-func _on_replays_id_pressed(_id):
-	$FileDialogReplay.show()
-
-
-func _on_file_dialog_replay_file_selected(path):
-	IM.perform_replay(path)
-
-
-func _on_editors_menu_id_pressed(id):
-	match id:
-		0: IM.go_to_map_editor()
-		1: UI.go_to_unit_editor()
-		_: pass
+	$MainContainer/TopMenu/ReplaysButton.set_disabled(not BattleReplay.has_replays())
 
 
 func _on_visibility_changed():
@@ -59,3 +44,19 @@ func _clear_tabs():
 	$MainContainer/HostLobby.hide()
 	$MainContainer/ClientLobby.hide()
 	$MainContainer/SettingsMenu.hide()
+
+
+func _on_replays_button_pressed():
+	$FileDialogReplay.show()
+
+
+func _on_file_dialog_replay_file_selected(path):
+	IM.perform_replay(path)
+
+
+func _on_unit_editor_button_pressed():
+	UI.go_to_unit_editor()
+
+
+func _on_map_editor_button_pressed():
+	IM.go_to_map_editor()

--- a/Scripts/UI/main_menu.gd
+++ b/Scripts/UI/main_menu.gd
@@ -35,20 +35,27 @@ func _on_visibility_changed():
 	refresh_replays_disabled()
 
 
-func _on_multiplayer_id_pressed(id):
-	match id:
-		0:
-			$MainContainer/HostLobby.show()
-			$MainContainer/ClientLobby.hide()
-			$MainContainer/SettingsMenu.hide()
-		1:
-			$MainContainer/HostLobby.hide()
-			$MainContainer/ClientLobby.show()
-			$MainContainer/SettingsMenu.hide()
-		_: pass
+func _on_host_button_pressed():
+	_clear_tabs()
+	$MainContainer/TopMenu/HostButton.modulate = Color.YELLOW
+	$MainContainer/HostLobby.show()
+
+
+func _on_join_button_pressed():
+	_clear_tabs()
+	$MainContainer/TopMenu/JoinButton.modulate = Color.YELLOW
+	$MainContainer/ClientLobby.show()
 
 
 func _on_settings_button_pressed():
+	_clear_tabs()
+	$MainContainer/TopMenu/SettingsButton.modulate = Color.YELLOW
+	$MainContainer/SettingsMenu.show()
+
+func _clear_tabs():
+	$MainContainer/TopMenu/HostButton.modulate = Color.WHITE
+	$MainContainer/TopMenu/JoinButton.modulate = Color.WHITE
+	$MainContainer/TopMenu/SettingsButton.modulate = Color.WHITE
 	$MainContainer/HostLobby.hide()
 	$MainContainer/ClientLobby.hide()
-	$MainContainer/SettingsMenu.show()
+	$MainContainer/SettingsMenu.hide()


### PR DESCRIPTION
- host/join/settings as tabs/buttons not menus
- removed ai button in battle lobby setup to make it consistent with world ui, take/leave is enough
- fix load error when picking  " - empty - " unit

![image](https://github.com/Wiolarz/Krong/assets/14243569/fcc8be0d-fe69-47a8-8456-cae6b05b6a06)
